### PR TITLE
Add shared module for OpenShift Operators

### DIFF
--- a/modules/what-operators-are.adoc
+++ b/modules/what-operators-are.adoc
@@ -1,0 +1,19 @@
+// Module included in the following:
+//
+// @bhardesty - Deploying AMQ Interconnect on OpenShift
+
+
+[id='what-operators-are-{context}']
+= What Operators are
+
+Operators are a method of packaging, deploying, and managing a Kubernetes application. They take human operational knowledge and encode it into software that is more easily shared with consumers to automate common or complex tasks.
+
+In OpenShift Container Platform 4.0, the _Operator Lifecycle Manager (OLM)_ helps users install, update, and generally manage the life cycle of all Operators and their associated services running across their clusters. It is part of the Operator Framework, an open source toolkit designed to manage Kubernetes native applications (Operators) in an effective, automated, and scalable way.
+
+The OLM runs by default in OpenShift Container Platform 4.0, which aids cluster administrators in installing, upgrading, and granting access to Operators running on their cluster. The OpenShift Container Platform web console provides management screens for cluster administrators to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
+
+_OperatorHub_ is the graphical interface that OpenShift cluster administrators use to discover, install, and upgrade Operators. With one click, these Operators can be pulled from OperatorHub, installed on the cluster, and managed by the OLM, ready for engineering teams to self-service manage the software in development, test, and production environments.
+
+.Additional resources
+
+* For more information about Operators, see the link:https://docs.openshift.com/container-platform/4.1/applications/operators/olm-what-operators-are.html[OpenShift documentation].


### PR DESCRIPTION
This module can be used in any doc that describes how to use an Operator. This version does not use any attributes or conditionals in order to make it as simple as possible to reuse.