### PR TITLE
WIP: Policies and procedures for sharing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repo contains modules that can be shared across Red Hat Middleware product 
 
 You can share either a single module, or a set of modules that can (or should) be reused together - such as in an assembly. To share a single module or a set of modules:
 
-1. Prepare the module (or modules) for reuse.
-2. Create a PR for the module (or modules).
+1. [Prepare the module (or modules) for reuse](#preparing-a-module-for-reuse).
+2. [Create a PR for the module (or modules)](#creating-a-pr-to-add-shared-modules).
 
 ### Preparing a module for reuse
 
@@ -42,7 +42,7 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 
 3. After the PR is merged:
 
-  * Update your book to point to the module. For more information, see #reusing-a-shared-module.
+  * Update your book to point to the module. For more information, see [Reusing a shared module](#reusing-a-shared-module).
   * If necessary, notify other Middleware writers about the shared module so that others can use it.
 
 TODO: describe how to share a module that includes images

--- a/README.md
+++ b/README.md
@@ -1,85 +1,76 @@
-# Instructions for grabbing shared modules
+# Shared modules for Red Hat Middleware docs
 
-## Prerequisites
+This repo contains modules that can be shared across Red Hat Middleware product docs.
 
-The following list of prerequisites only need to be done once and might require help from your DPM or Strategist. 
+## Sharing modules
 
-- A repository in GitLab or GitHub for your documentation 
-- The git-export script edited for your project
-- Generate an SSH key pair in the Terminal.
-- Add your public SSH key to your GitLab or GitHub profile.
-  - For help on the two above tasks on GitLab, see https://gitlab.cee.redhat.com/help/ssh/README 
-  - For help on the two above tasks on GitHub, see https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/ 
+You can share either a single module, or a set of modules that can (or should) be reused together - such as in an assembly. To share a single module or a set of modules:
 
-## Setting up files and directory 
-1. At your base add a snippets/ folder
-2. Edit your attributes.adoc file to include a pointer to snippets
-```
-:SnippetDir: snippets/modules
-``` 
-3. When including a snippet in your assemblies use the SnippetDir attribute
-```
-include::{SnippetDir}/concept-operators.adoc[leveloffset=+1]
+1. Prepare the module (or modules) for reuse.
+2. Create a PR for the module (or modules).
+
+### Preparing a module for reuse
+
+Before you can share a module, you must prepare it for reuse. This ensures that anyone can quickly see who is using the module, and where they are using it. That way, if the module ever needs to be updated, you can notify the writers whose publications will be affected by the change.
+
+* In the module, add a comment at the top indicating your GitHub user name and the book in which the module is used. For example:
+
+ ```
+ // Module included in the following:
+ //
+ // @bhardesty - Deploying AMQ Interconnect on OpenShift
 ```
 
-## Setting up repository connections
+### Creating a PR to add shared modules
 
-1. Fork your documentation repository.
-2. Open Terminal.
-3. Navigate to the directory where you want to create the new repository folder.
-4. Type the following command:
-```
-git clone <FORKED REPOSITORY SSH URL>`
-```
-5. Navigate to the newly created folder.
-```
-cd <FORKED REPOSITORY FOLDER>
-```
-6. Check that your fork is set as the remote named ‘origin’
-```
-$ git remote -v
-origin	git@gitlab.cee.redhat.com:<username>/amq-online-gerrit3.git (fetch)
-origin	git@gitlab.cee.redhat.com:<username>/amq-online-gerrit3.git (push)
-```
-7. Add the shared snippets repo as a remote repository and fetch its contents. This allows you to check out and work with the latest source code.
-```
-git remote add -f snippets  git@github.com:redhat-documentation/mw-shared-modules.git
-Verify the new remote was added:
-[amq-streams]$ git remote -v
-snippets	git@github.com:redhat-documentation/mw-shared-modules.git (fetch)
-snippets	git@github.com:redhat-documentation/mw-shared-modules.git (push)
-origin	git@gitlab.cee.redhat.com:<username>/amq-online-gerrit3.git (fetch)
-origin	git@gitlab.cee.redhat.com:<username>/amq-online-gerrit3.git (push)
-```
-## Pushing to your docs repo from snippets 
+After preparing the module (or modules) for reuse, you must create a PR to add it to the `mw-shared-modules/modules/` directory in this repository.
 
-1. Refresh your fork:
-```
-cd <FORKED REPOSITORY FOLDER>
-git checkout master 
-git pull --rebase snippets master
-git push origin HEAD
-```
-2. Check out a new branch:
-```
-git checkout -b sync-<yyyy-mm-dd>
-```
-3. Refresh the upstream folder:
-```
-rm -rf snippets/$* snippets/$*.revisiong
-scripts/git-export "https://github.com/redhat-documentation/mw-shared-modules.git" master snippets/$*
-git add --all snippets
-```
-4. Commit new upstream to your repo:
-```
-git commit -a -m "<your_message>"
-git push origin HEAD
-```
-5. If new assemblies have been added remember to update books/master.adoc
-6. If new attributes have been added remember to update books/common/attributes.adoc
-7. Merge synced content:
-  - Go to your fork
-  - Click Merge or Pull Requests (on the left if in GitLab)
-  - Create the merge request.
-  - Finalize the merge in the repo
+1. If you are sharing a set of modules (as opposed to a single module):
 
+    a. In the `mw-shared-modules/modules/` directory, add a new directory for your set of modules. For an example, see `mw-shared-modules/modules/prometheus/`.
+
+    b. Add your modules to the directory that you created.
+
+    c. Add a README.md file and describe how the set of modules should be used.
+
+      * List any attributes that the modules use.
+      * Describe how the modules should be included. At a minimum, define the order in which the modules should be included.
+
+2. Create a PR to add the module.
+
+2. Wait. The PR will be reviewed and, once approved, merged.
+
+3. After the PR is merged:
+  * Update your book to point to the module. For more information, see #reusing-a-shared-module.
+
+  * If necessary, notify other Middleware writers about the shared module so that others can use it.
+
+TODO: describe how to share a module that includes images
+
+## Updating a shared module
+
+Making a change to a shared module impacts every book in which the module is used. Therefore, communication is important.
+
+1. Create a PR with your updates.
+
+2. In the PR, tag each writer who is listed in the comments in the beginning of the module.
+
+3. Wait. Make sure that all affected writers have an opportunity to review your changes and determine how to implement the updated module in their books.
+
+## Reusing a shared module
+
+1. In the assembly in which the module should be used, include the module using the URL of the module's location.
+
+  For example, to point to the _What operators are_ module:
+  ```
+  include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
+  ```
+
+2. If the shared module uses any attributes, define them in the assembly in which you included the module.
+
+  For example, say the shared module uses an attribute called `:ProdName:` to represent the product name, but your book already uses a different attribute (say, `:ProductName:`) for the same thing. To use the shared module, you would add `:ProdName:` and set it to the value of `:ProductName:`:
+
+  ```
+  :ProdName: {ProductName}
+  include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
+  ```   

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 
 2. Create a PR to add the module.
 
-2. Wait. The PR will be reviewed and, once approved, merged.
+3. Wait. The PR will be reviewed and, once approved, merged.
 
 3. After the PR is merged:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 
 3. Wait. The PR will be reviewed and, once approved, merged.
 
-3. After the PR is merged:
+4. After the PR is merged:
 
    * Update your book to point to the module. For more information, see [Reusing a shared module](#reusing-a-shared-module).
    * If necessary, notify other Middleware writers about the shared module so that others can use it.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Before you can share a module, you must prepare it for reuse. This ensures that 
 
 * In the module, add a comment at the top indicating your GitHub user name and the book in which the module is used. For example:
 
- ```
- // Module included in the following:
- //
- // @bhardesty - Deploying AMQ Interconnect on OpenShift
-```
+   ```
+   // Module included in the following:
+   //
+   // @bhardesty - Deploying AMQ Interconnect on OpenShift
+  ```
 
 ### Creating a PR to add shared modules
 
@@ -31,7 +31,7 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 
     b. Add your modules to the directory that you created.
 
-    c. Add a README.md file and describe how the set of modules should be used.
+    c. Add a `README.md` file and describe how the set of modules should be used.
 
       * List any attributes that the modules use.
       * Describe how the modules should be included. At a minimum, define the order in which the modules should be included.
@@ -41,8 +41,8 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 2. Wait. The PR will be reviewed and, once approved, merged.
 
 3. After the PR is merged:
-  * Update your book to point to the module. For more information, see #reusing-a-shared-module.
 
+  * Update your book to point to the module. For more information, see #reusing-a-shared-module.
   * If necessary, notify other Middleware writers about the shared module so that others can use it.
 
 TODO: describe how to share a module that includes images
@@ -59,18 +59,17 @@ Making a change to a shared module impacts every book in which the module is use
 
 ## Reusing a shared module
 
-1. In the assembly in which the module should be used, include the module using the URL of the module's location.
+1. In the assembly in which the module should be used, include the module using the URL of the module's location. For example, to point to the _What operators are_ module:
 
-  For example, to point to the _What operators are_ module:
-  ```
-  include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
-  ```
+   ```
+   include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
+   ```
 
 2. If the shared module uses any attributes, define them in the assembly in which you included the module.
 
-  For example, say the shared module uses an attribute called `:ProdName:` to represent the product name, but your book already uses a different attribute (say, `:ProductName:`) for the same thing. To use the shared module, you would add `:ProdName:` and set it to the value of `:ProductName:`:
+   For example, say the shared module uses an attribute called `:ProdName:` to represent the product name, but your book already uses a different attribute (say, `:ProductName:`) for the same thing. To use the shared module, you would add `:ProdName:` and set it to the value of `:ProductName:`:
 
-  ```
-  :ProdName: {ProductName}
-  include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
-  ```   
+   ```
+   :ProdName: {ProductName}
+   include::https://raw.githubusercontent.com/redhat-documentation/mw-shared-modules/master/modules/what-operators-are.adoc[leveloffset=+1]
+   ```   

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ After preparing the module (or modules) for reuse, you must create a PR to add i
 
 3. After the PR is merged:
 
-  * Update your book to point to the module. For more information, see [Reusing a shared module](#reusing-a-shared-module).
-  * If necessary, notify other Middleware writers about the shared module so that others can use it.
+   * Update your book to point to the module. For more information, see [Reusing a shared module](#reusing-a-shared-module).
+   * If necessary, notify other Middleware writers about the shared module so that others can use it.
 
 TODO: describe how to share a module that includes images
 


### PR DESCRIPTION
This is an initial stab at some policies and procedures for sharing modules, reusing them in a RH Middleware book, and making updates to a shared module. There are still some items to consider, such as how to handle modules with images.