### PR TITLE
add comment for subscription module reuse in service registry guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,14 @@ To reuse a shared module by using a remote include:
 4. To use the assembly in your book, include the combined assembly in your book's `master.adoc` file.
 
    **NOTE:** You must include the combined assembly that was created by `getRemote.sh`, *not* the original assembly in which you added the remote include.
+   
+5. Add a comment at the top of the reused module with your GitHub user name and the book in which the module is reused. For example:
+
+   ```
+   // Module included in the following:
+   //
+   // @bhardesty - Using AMQ Interconnect
+   // @smccarthy-ie - Getting Started with Service Registry
+   //
+   ...
+   ```

--- a/modules/using-your-subscription.adoc
+++ b/modules/using-your-subscription.adoc
@@ -1,6 +1,7 @@
 // Module included in the following:
 //
 // @bhardesty - Using AMQ Interconnect
+// @smccarthy-ie - Getting Started with Service Registry
 //
 // Attributes used:
 


### PR DESCRIPTION
Adds a comment on reusing the subscription module in the Service Registry guide, and updates the shared module readme with extra step to update resued modules with user and book names.