### PR TITLE
change slash to dash for valid label

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -35,7 +35,7 @@
 
 :component-type: application
 :product-name: "Red_Hat_Runtimes"
-:product-version: 2020/Q2
+:product-version: 2020-Q2
 
 //
 //Links


### PR DESCRIPTION
Some testing has revealed that forward slash characters are not allowed in labels. Change "/" to "-".