### PR TITLE
Update the product-version metering label to 2021-Q1

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -35,7 +35,7 @@
 
 :component-type: application
 :product-name: "Red_Hat_Runtimes"
-:product-version: 2020-Q2
+:product-version: 2021-Q1
 
 //
 //Links


### PR DESCRIPTION
@oraNod @ncbaratta 
Quarkus QE has requested that the `product-version` pod label for metering match the current release. 
I have updated the label to `2021-Q1`.

Please let me know if this is OK. and if it is please feel free to merge this PR.
Please let me know if you have questions or comments.

Thank you:)