### PR TITLE
RHDG/JWS integration attributes

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -6,6 +6,26 @@
 :runtimes-short: Runtimes
 
 //
+// Cross-product naming attributes
+//
+
+// Each Runtimes product needs a unique name attribute for shared content.
+
+:rhdg-long: Red Hat Data Grid
+:rhdg-short: Data Grid
+
+:jws-long: Red Hat JBoss Web Server
+:jws-short: JBoss Web Server
+
+//
+// RHDG and JWS session externalization
+//
+
+:tomcat_session_client: redhat-datagrid-8.2.0.Final-tomcat<$version>-session-client.zip
+:rhdg_download_url: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions
+:rhdg_hotrod_client_api_url: https://access.redhat.com/webassets/avalon/d/red-hat-data-grid/8.2/api/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+
+//
 //Metering labels: product specific
 //
 


### PR DESCRIPTION
For Pantheon v2, it's going to make our lives easier if we have less attributes.adoc files. This PR moves attributes from the RHDG repo into runtimes-common. These attributes are shared between RHDG and JWS doc sets for the session externalization user story.