### PR TITLE
add long and short name attributes for Red Hat build of Quarkus

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -17,6 +17,9 @@
 :jws-long: Red Hat JBoss Web Server
 :jws-short: JBoss Web Server
 
+:runtimes-rhbq-long: Red Hat build of Quarkus
+:runtimes-rhbq-short: Quarkus
+
 //
 // RHDG and JWS session externalization
 //

--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -10,7 +10,8 @@
 //
 
 // Each Runtimes product needs a unique name attribute for shared content.
-// When you write shared content, use the following attributes instead of the regular product name attributes of your project to ensure that correct product names are substituted when you reuse content across different documentation sets. 
+// When you write shared content, use the following attributes instead of product name attributes specific to your project. 
+// These attributes ensure that correct product names are substituted in shared content sets. 
 
 :rhdg-long: Red Hat Data Grid
 :rhdg-short: Data Grid

--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -10,6 +10,7 @@
 //
 
 // Each Runtimes product needs a unique name attribute for shared content.
+// When you write shared content, use the following attributes instead of the regular product name attributes of your project to ensure that correct product names are substituted when you reuse content across different documentation sets. 
 
 :rhdg-long: Red Hat Data Grid
 :rhdg-short: Data Grid

--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -10,17 +10,17 @@
 //
 
 // Each Runtimes product needs a unique name attribute for shared content.
-// When you write shared content, use the following attributes instead of product name attributes specific to your project. 
-// These attributes ensure that correct product names are substituted in shared content sets. 
+// When you write shared content, use the following attributes instead of product name attributes specific to your project.
+// These attributes ensure that correct product names are substituted in shared content sets.
 
-:rhdg-long: Red Hat Data Grid
-:rhdg-short: Data Grid
+:runtimes-datagrid-long: Red Hat Data Grid
+:runtimes-datagrid-short: Data Grid
 
-:jws-long: Red Hat JBoss Web Server
-:jws-short: JBoss Web Server
+:runtimes-webserver-long: Red Hat JBoss Web Server
+:runtimes-webserver-short: JBoss Web Server
 
-:runtimes-rhbq-long: Red Hat build of Quarkus
-:runtimes-rhbq-short: Quarkus
+:runtimes-quarkus-long: Red Hat build of Quarkus
+:runtimes-quarkus-short: Quarkus
 
 //
 // RHDG and JWS session externalization


### PR DESCRIPTION
Hi, @oraNod 
I've added the attributes for the long and short version of  the product names for Red Hat build of Quarkus.
I added the `runtimes-` prefix to the attribute name to make them more easily distinguishable from similarly named product-specific attributes.
I have not added the `runtimes-` prefix to the attributes for other products, yet, but I can do so, if we decide to go with it.

Please let me know what you think.
