### PR TITLE
update runtimes metering labels

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -44,16 +44,21 @@
 //:component-version: x.y.z
 
 //Define the component name.
-//:component-name: "Data_Grid"
-//:component-name: "Vert.X"
-//:component-name: "EAP"
-//:component-name: "JBoss_Web_Server"
-//:component-name: "SSO"
-//:component-name: "AMQ_Broker"
-//:component-name: "Quarkus"
-//:component-name: "Spring_Boot"
-//:component-name: "Thorntail"
-//:component-name: "Node.js"
+//:component-name: Data_Grid
+//:component-name: Vert.X
+//:component-name: EAP
+//:component-name: JBoss_Web_Server
+//:component-name: SSO
+//:component-name: AMQ_Broker
+//:component-name: Quarkus
+//:component-name: Spring_Boot
+//:component-name: Thorntail
+//:component-name: Node.js
+
+//Define the subcomponent name if applicable.
+//:sub-component-name: Tomcat <major_version>
+//:sub-component-name: SSO Server
+//:sub-component-name: <leave_blank>
 
 //Be sure ProductName resolves if you don't already define it.
 //:ProductName: Data Grid
@@ -65,8 +70,8 @@
 //These metering labels apply to all Runtimes products. Do not change them.
 
 :component-type: application
-:product-name: "Red_Hat_Runtimes"
-:product-version: 2021-Q1
+:product-name: Red_Hat_Runtimes
+:product-version: YYYY-Q1
 
 //
 //Links

--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -57,7 +57,7 @@
 
 //Define the subcomponent name if applicable.
 //:sub-component-name: Tomcat <major_version>
-//:sub-component-name: SSO Server
+//:sub-component-name: SSO_Server
 //:sub-component-name: <leave_blank>
 
 //Be sure ProductName resolves if you don't already define it.

--- a/runtimes-common/ref_runtimes_metering_labels.adoc
+++ b/runtimes-common/ref_runtimes_metering_labels.adoc
@@ -14,13 +14,14 @@ Do not add metering labels to any pods that an operator or a template deploys an
 
 {ProductName} can use the following metering labels:
 
-* `com.redhat.component-name: {component-name}`
-* `com.redhat.component-type: {component-type}`
-* `com.redhat.component-version: {component-version}`
-* `com.redhat.product-name: {product-name}`
-* `com.redhat.product-version: {product-version}`
+* `com.company: Red_Hat`
+* `rht.prod_name: {product-name}`
+* `rht.prod_ver: {product-version}`
+* `rht.comp: {component-name}`
+* `rht.comp_ver: {component-version}`
+* `rht.subcomp: {sub-component-name}`
+* `rht.subcomp_t: {component-type}`
 
 [role="_additional-resources"]
 .Additional resources
-
 * link:{metering-doc-root}[Configuring and using Metering in OpenShift Container Platform]


### PR DESCRIPTION
Updates for changes from https://docs.jboss.org/display/RHMWRT/Metering+Runtimes+in+OpenShift 

Adds new attribute for the subcomponent labels. Required action for doc teams to include that attribute value after the sync.