### PR TITLE
remove links.doc from attributes file

### DIFF
--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -9,7 +9,9 @@
 // Include shared link attributes
 //
 
-include::links.adoc[]
+:metering-doc-root: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/metering/index
+
+:redhat-tech-previews: https://access.redhat.com/support/offerings/techpreview/[Red Hat Technology Preview Features Support Scope]
 
 //
 // Cross-product naming attributes


### PR DESCRIPTION
Remove links.doc from attributes file and include links for the shared content directly in the runtimes-attributes.adoc (Pantheon2 does not support any include statement in the attributes file)
